### PR TITLE
Update tests for 2021

### DIFF
--- a/__tests__/creator-spec.ts
+++ b/__tests__/creator-spec.ts
@@ -80,7 +80,8 @@ const testIncludesBase = (title: string, expectation: boolean , ...content: Arra
       // We want to be able to search across line breaks and multiple spaces.
       const singleLineWxContent = wxsContent.replace(/\s\s+/g, ' ');
       content.forEach((innerContent) => {
-        expect(singleLineWxContent.includes(innerContent)).toBe(expectation);
+        if (expectation) expect(singleLineWxContent).toContain(innerContent);
+        else expect(singleLineWxContent).not.toContain(innerContent);
       });
     }
   });
@@ -142,7 +143,7 @@ testIncludes('an APPLICATIONROOTDIRECTORY', '<Directory Id="APPLICATIONROOTDIREC
 
 testIncludes('an ApplicationProgramsFolder', '<Directory Id="ApplicationProgramsFolder"');
 
-testIncludes('a default appUserModelId', 'Key="System.AppUserModel.ID" Value="com.squirrel.Acme.acme"');
+testIncludes('a default appUserModelId', 'Key="System.AppUserModel.ID" Value="com.squirrel.acme.acme"');
 
 regexTestIncludes('versioned app folder', /<Directory\s*Id=".*"\s*Name="app-1\.0\.0"/);
 
@@ -515,7 +516,7 @@ describe('auto-launch', () => {
   });
 
   testIncludes('RegistryRunKey', '<RegistryKey Root="HKMU" Key="SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run" ForceCreateOnInstall="no" ForceDeleteOnUninstall="no"');
-  testIncludes('RegistryRunKeyValue', '<RegistryValue Name="com.squirrel.Acme.acme" Type="string" Value="&quot;[APPLICATIONROOTDIRECTORY]acme.exe&quot;" KeyPath="yes"/>');
+  testIncludes('RegistryRunKeyValue', '<RegistryValue Name="com.squirrel.acme.acme" Type="string" Value="&quot;[APPLICATIONROOTDIRECTORY]acme.exe&quot;" KeyPath="yes"/>');
   testIncludes('RegistryRunKey component', '<Component Id="RegistryRunKey"');
   testIncludes('RegistryRunKey component-ref', '<ComponentRef Id="RegistryRunKey" />');
   regexTestIncludes('AutoLaunch feature', /<Feature Id="AutoLaunch" Title="Launch On Login" Level="2" .*>/);
@@ -530,7 +531,7 @@ describe('auto-launch', () => {
     expect(wxsFile).toBeTruthy();
   });
 
-  testIncludes('RegistryRunKey', '<RegistryValue Name="com.squirrel.Acme.acme" Type="string" Value="&quot;[APPLICATIONROOTDIRECTORY]acme.exe&quot; arg1 arg2" KeyPath="yes"/>');
+  testIncludes('RegistryRunKey', '<RegistryValue Name="com.squirrel.acme.acme" Type="string" Value="&quot;[APPLICATIONROOTDIRECTORY]acme.exe&quot; arg1 arg2" KeyPath="yes"/>');
 
 });
 

--- a/__tests__/utils/rc-edit-spec.ts
+++ b/__tests__/utils/rc-edit-spec.ts
@@ -19,7 +19,7 @@ const acmeExeRegex = process.platform === 'win32' ? /C:\\tmp\\acme.*\\acme\.exe/
 const acmeFileInfo = { 'version-string':
   { CompanyName: 'acme corp',
     FileDescription: 'a test',
-    LegalCopyright: '2020@acme corp',
+    LegalCopyright: '2021@acme corp',
     ProductName: 'acme' },
   'file-version': '1.2.3',
   'product-version': '1.2.3',
@@ -51,7 +51,7 @@ test('transfers exe file info to stub exe', async () => {
     callback(null, {
       CompanyName: 'acme corp',
       FileDescription: 'a test',
-      LegalCopyright: '2020@acme corp',
+      LegalCopyright: '2021@acme corp',
       ProductName: 'acme',
       FileVersion: '1.2.3',
       ProductVersion: '1.2.3'
@@ -74,7 +74,7 @@ test('uses parameter if rcinfo fails', async () => {
   const wayneOptions = { 'version-string':
   { CompanyName: 'Wayne Enterprise',
     FileDescription: 'I am Batman',
-    LegalCopyright: '2020@Wayne Enterprise',
+    LegalCopyright: '2021@Wayne Enterprise',
     ProductName: 'bat-app' },
   'file-version': '3.3.3',
   'product-version': '3.3.3',
@@ -93,7 +93,7 @@ test('uses an explicitly provided app icon for the stub exe', async () => {
     callback(null, {
       CompanyName: 'acme corp',
       FileDescription: 'a test',
-      LegalCopyright: '2020@acme corp',
+      LegalCopyright: '2021@acme corp',
       ProductName: 'acme',
       FileVersion: '1.2.3',
       ProductVersion: '1.2.3'
@@ -115,7 +115,7 @@ test('it users no icon if extraction fails and no explicit one is provided', asy
     callback(null, {
       CompanyName: 'acme corp',
       FileDescription: 'a test',
-      LegalCopyright: '2020@acme corp',
+      LegalCopyright: '2021@acme corp',
       ProductName: 'acme',
       FileVersion: '1.2.3',
       ProductVersion: '1.2.3'
@@ -141,7 +141,7 @@ test('it users no icon if icon extractor module is not available', async () => {
     callback(null, {
       CompanyName: 'acme corp',
       FileDescription: 'a test',
-      LegalCopyright: '2020@acme corp',
+      LegalCopyright: '2021@acme corp',
       ProductName: 'acme',
       FileVersion: '1.2.3',
       ProductVersion: '1.2.3'


### PR DESCRIPTION
Some tests are currently failing because they are
reading the current year and comparing it against
"2020".
This change updates the tests to expect "2021" instead.